### PR TITLE
Pd/user login endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,6 @@ gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.2', require: false
 
-# Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
 gem 'bcrypt', '~> 3.1.7'
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :development, :test do
   gem 'shoulda-matchers'
   gem 'simplecov'
   gem 'factory_bot_rails'
+  gem 'faker'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    bcrypt (3.1.16)
     bindex (0.8.1)
     bootsnap (1.7.2)
       msgpack (~> 1.0)
@@ -223,6 +224,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
   byebug
   capybara

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,8 @@ GEM
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
+    faker (2.16.0)
+      i18n (>= 1.6, < 2)
     ffi (1.14.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -229,6 +231,7 @@ DEPENDENCIES
   byebug
   capybara
   factory_bot_rails
+  faker
   jbuilder (~> 2.7)
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/api/v0/sessions_controller.rb
+++ b/app/controllers/api/v0/sessions_controller.rb
@@ -1,0 +1,12 @@
+class Api::V0::SessionsController < ApplicationController
+  def create
+    user = User.find_by(email: params[:email])
+    if user.authenticate(params[:password])
+      user.generate_api_token
+      message = "user authenticated"
+      render json: {'auth_token' => user.auth_token, 'message' => message}, status: 200
+    else
+      message = "Invalid user credentials"
+    end
+  end
+end

--- a/app/controllers/api/v0/sessions_controller.rb
+++ b/app/controllers/api/v0/sessions_controller.rb
@@ -7,6 +7,7 @@ class Api::V0::SessionsController < ApplicationController
       render json: {'auth_token' => user.auth_token, 'message' => message}, status: 200
     else
       message = "Invalid user credentials"
+      render json: {'data' => message}, status: 401
     end
   end
 end

--- a/app/controllers/api/v0/sessions_controller.rb
+++ b/app/controllers/api/v0/sessions_controller.rb
@@ -1,7 +1,10 @@
 class Api::V0::SessionsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
   def create
-    user = User.find_by(email: params[:email])
-    if user.authenticate(params[:password])
+    request_body = JSON.parse(request.body.read)
+    user = User.find_by(email: request_body['email'])
+    if user.authenticate(request_body['password'])
       user.generate_api_token
       message = "user authenticated"
       render json: {'auth_token' => user.auth_token, 'message' => message}, status: 200

--- a/app/controllers/api/v0/users_controller.rb
+++ b/app/controllers/api/v0/users_controller.rb
@@ -1,0 +1,11 @@
+class Api::V0::UsersController < ApplicationController
+  def create
+    user = User.create(user_params)
+    user.save
+  end
+
+  private
+  def user_params
+    params.require(:user).permit(:email, :password, :password_confirmation)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,9 @@ class User < ApplicationRecord
   validates_uniqueness_of :email
   validates_presence_of :email
   validates_presence_of :password
+
+  def generate_api_token
+    token = AuthTokenGenerator.generate_token
+    self.update(auth_token: token)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,7 @@
+class User < ApplicationRecord
+  has_secure_password
+
+  validates_uniqueness_of :email
+  validates_presence_of :email
+  validates_presence_of :password
+end

--- a/app/poros/auth_token_generator.rb
+++ b/app/poros/auth_token_generator.rb
@@ -1,0 +1,7 @@
+require 'securerandom'
+
+class AuthTokenGenerator
+  def self.generate_token
+    SecureRandom.base64(400)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,8 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v0 do
+      post '/login', to: 'sessions#create'
+    end
+  end
 end

--- a/db/migrate/20210222205614_create_users.rb
+++ b/db/migrate/20210222205614_create_users.rb
@@ -1,0 +1,9 @@
+class CreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users do |t|
+      t.string :email
+      t.string :password_digest
+      t.string :auth_token
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2021_02_22_205614) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "password_digest"
+    t.string "auth_token"
+  end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,7 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+User.destroy_all
+
+user_1 = User.create(email: "sample.coach@mobile.edu", password: "samplepassword")
+users = FactoryBot.create_list(:user, 10)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    email  { Faker::Internet.unique.email }
+    password { "password" }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'validations' do
+    it {should validate_presence_of(:email)}
+    it {should validate_presence_of(:password)}
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -52,3 +52,10 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/spec/requests/api/v0/login_request_spec.rb
+++ b/spec/requests/api/v0/login_request_spec.rb
@@ -1,14 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe 'User Login Endpoint Request' do
-  it 'A successful response returns an api_token with a 200 status' do
+  it 'A successful response returns an auth_token with a 200 status' do
     user = User.create( email: 'sample.coach@mobile.edu',
                         password: 'samplepassword')
 
-    post '/api/v0/login', body: { email: user.email,
+    post '/api/v0/login', params: { email: user.email,
                                   password: user.password}
 
-
     expect(response).to be_successful
+    expect(response.status).to eq(200)
+    json = JSON.parse(response.body, symbolize_names: true)
+    expect(json[:message]).to eq("user authenticated")
+    expect(json[:auth_token]).not_to eq(nil)
+    expect(json.keys.include?(:auth_token)).to eq(true)
+    expect(json.keys.include?(:message)).to eq(true)
   end
 end

--- a/spec/requests/api/v0/login_request_spec.rb
+++ b/spec/requests/api/v0/login_request_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe 'User Login Endpoint Request' do
     user = User.create( email: 'sample.coach@mobile.edu',
                         password: 'samplepassword')
 
-    post '/api/v0/login', params: { email: user.email,
-                                  password: user.password}
+    payload = { email: user.email, password: user.password}.to_json
+    post '/api/v0/login', params: payload
 
     expect(response).to be_successful
     expect(response.status).to eq(200)
@@ -21,8 +21,8 @@ RSpec.describe 'User Login Endpoint Request' do
     user_2 = User.create( email: 'sample.coach_2@mobile.edu',
                         password: 'password')
 
-    post '/api/v0/login', params: { email: user_2.email,
-                                    password: 'incorrectPassword'}
+    payload = { email: user_2.email, password: 'invalidpassword'}.to_json
+    post '/api/v0/login', params: payload
 
     expect(response).not_to be_successful
     expect(response.status).to eq(401)

--- a/spec/requests/api/v0/login_request_spec.rb
+++ b/spec/requests/api/v0/login_request_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe 'User Login Endpoint Request' do
+  it 'A successful response returns an api_token with a 200 status' do
+    user = User.create( email: 'sample.coach@mobile.edu',
+                        password: 'samplepassword')
+
+    post '/api/v0/login', body: { email: user.email,
+                                  password: user.password}
+
+
+    expect(response).to be_successful
+  end
+end

--- a/spec/requests/api/v0/login_request_spec.rb
+++ b/spec/requests/api/v0/login_request_spec.rb
@@ -16,4 +16,17 @@ RSpec.describe 'User Login Endpoint Request' do
     expect(json.keys.include?(:auth_token)).to eq(true)
     expect(json.keys.include?(:message)).to eq(true)
   end
+
+  it 'Incorrect login credentials return 401 error message' do
+    user_2 = User.create( email: 'sample.coach_2@mobile.edu',
+                        password: 'password')
+
+    post '/api/v0/login', params: { email: user_2.email,
+                                    password: 'incorrectPassword'}
+
+    expect(response).not_to be_successful
+    expect(response.status).to eq(401)
+    json = JSON.parse(response.body, symbolize_names: true)
+    expect(json[:data]).to eq("Invalid user credentials")
+  end
 end


### PR DESCRIPTION
Functionality exposes the `/api/v0/login` endpoint.
- Create user controller and model 
- Add migration for User table with `email`, `password_digest`, and `auth_token` columns. 
- Create SessionsController to enable user logon. 
- SessionsController Create method allows user logon, as well as routing to the User model to generate an auth_token.
- Add test for 200 `OK` response
- Add test for 401 `Unauthorized` response

Testing Coverage
4 examples, 0 failures

Coverage report generated for RSpec to /Users/pauldebevec/technical_challenge/CaptianUAssessment/coverage. 47 / 47 LOC (100.0%) covered.