### PR TITLE
Pd/team player coach relationships

### DIFF
--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,4 +1,6 @@
 class Player < ApplicationRecord
   validates_presence_of :first_name, :last_name, :height, :weight, :birthday,
                         :graduation_year, :position
+
+  belongs_to :team, optional: true
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,7 +1,7 @@
 class Team < ApplicationRecord
   validates_presence_of :name
   validates_presence_of :age_group, require: false
-  validates_presence_of :coach, require: false
 
   has_many :players
+  has_many :users
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,4 +2,6 @@ class Team < ApplicationRecord
   validates_presence_of :name
   validates_presence_of :age_group, require: false
   validates_presence_of :coach, require: false
+
+  has_many :players
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,9 @@ class User < ApplicationRecord
   has_secure_password
 
   validates_uniqueness_of :email
-  validates_presence_of :email
-  validates_presence_of :password
+  validates_presence_of :full_name, :email, :password
+
+  belongs_to :team, optional: true
 
   def generate_api_token
     token = AuthTokenGenerator.generate_token

--- a/db/migrate/20210223183448_create_players.rb
+++ b/db/migrate/20210223183448_create_players.rb
@@ -8,7 +8,7 @@ class CreatePlayers < ActiveRecord::Migration[6.0]
       t.string :birthday
       t.integer :graduation_year
       t.string :position
-      t.boolean :recruit
+      t.boolean :recruit, default: false
 
       t.timestamps
     end

--- a/db/migrate/20210223191355_create_teams.rb
+++ b/db/migrate/20210223191355_create_teams.rb
@@ -3,7 +3,7 @@ class CreateTeams < ActiveRecord::Migration[6.0]
     create_table :teams do |t|
       t.string :name
       t.string :age_group
-      t.string :coach
+      t.string :coach, default: ''
 
       t.timestamps
     end

--- a/db/migrate/20210223195645_add_team_id_to_player.rb
+++ b/db/migrate/20210223195645_add_team_id_to_player.rb
@@ -1,0 +1,5 @@
+class AddTeamIdToPlayer < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :players, :team, null: true, foreign_key: true
+  end
+end

--- a/db/migrate/20210223233443_add_full_name_to_users.rb
+++ b/db/migrate/20210223233443_add_full_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddFullNameToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :full_name, :string
+  end
+end

--- a/db/migrate/20210223234443_add_team_to_users.rb
+++ b/db/migrate/20210223234443_add_team_to_users.rb
@@ -1,0 +1,5 @@
+class AddTeamToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :users, :team, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_23_191355) do
+ActiveRecord::Schema.define(version: 2021_02_23_195645) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,9 +23,11 @@ ActiveRecord::Schema.define(version: 2021_02_23_191355) do
     t.string "birthday"
     t.integer "graduation_year"
     t.string "position"
-    t.boolean "recruit"
+    t.boolean "recruit", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "team_id"
+    t.index ["team_id"], name: "index_players_on_team_id"
   end
 
   create_table "teams", force: :cascade do |t|
@@ -42,4 +44,5 @@ ActiveRecord::Schema.define(version: 2021_02_23_191355) do
     t.string "auth_token"
   end
 
+  add_foreign_key "players", "teams"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_23_195645) do
+ActiveRecord::Schema.define(version: 2021_02_23_234443) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 2021_02_23_195645) do
   create_table "teams", force: :cascade do |t|
     t.string "name"
     t.string "age_group"
-    t.string "coach"
+    t.string "coach", default: ""
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -42,7 +42,11 @@ ActiveRecord::Schema.define(version: 2021_02_23_195645) do
     t.string "email"
     t.string "password_digest"
     t.string "auth_token"
+    t.string "full_name"
+    t.bigint "team_id"
+    t.index ["team_id"], name: "index_users_on_team_id"
   end
 
   add_foreign_key "players", "teams"
+  add_foreign_key "users", "teams"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,11 +1,46 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
 User.destroy_all
+Player.destroy_all
+Team.destroy_all
 
-user_1 = User.create(email: "sample.coach@mobile.edu", password: "samplepassword")
-users = FactoryBot.create_list(:user, 10)
+
+coach_and_team_1 = FactoryBot.create(:user, team_id: FactoryBot.create(:team).id)
+coach_and_team_1.team.update(coach: coach_and_team_1.full_name)
+team_1 = coach_and_team_1.team
+
+coach_and_team_2 = FactoryBot.create(:user, team_id: FactoryBot.create(:team).id)
+coach_and_team_2.team.update(coach: coach_and_team_2.full_name)
+team_2 = coach_and_team_2.team
+
+coach_and_team_3 = FactoryBot.create(:user, team_id: FactoryBot.create(:team).id)
+coach_and_team_3.team.update(coach: coach_and_team_3.full_name)
+team_3 = coach_and_team_3.team
+
+coach_and_team_4 = FactoryBot.create(:user, team_id: FactoryBot.create(:team).id)
+coach_and_team_4.team.update(coach: coach_and_team_4.full_name)
+team_4 = coach_and_team_4.team
+
+coach_and_team_5 = FactoryBot.create(:user, team_id: FactoryBot.create(:team).id)
+coach_and_team_5.team.update(coach: coach_and_team_5.full_name)
+team_5 = coach_and_team_5.team
+
+coach_and_team_6 = FactoryBot.create(:user, team_id: FactoryBot.create(:team).id)
+coach_and_team_6.team.update(coach: coach_and_team_6.full_name)
+team_6 = coach_and_team_6.team
+
+team_1_players = FactoryBot.create_list(:player, 5)
+team_1.players << team_1_players
+
+team_2_players = FactoryBot.create_list(:player, 5)
+team_2.players << team_2_players
+
+team_3_players = FactoryBot.create_list(:player, 5)
+team_3.players << team_3_players
+
+team_4_players = FactoryBot.create_list(:player, 5)
+team_4.players << team_4_players
+
+team_5_players = FactoryBot.create_list(:player, 5)
+team_5.players << team_5_players
+
+team_6_players = FactoryBot.create_list(:player, 5)
+team_6.players << team_6_players

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :team do
+    name  { Faker::Team.name }
+    age_group  { '16-18' }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :user do
+    full_name  { Faker::FunnyName.two_word_name }
     email  { Faker::Internet.unique.email }
     password { "password" }
   end

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -10,4 +10,8 @@ RSpec.describe Player, type: :model do
     it {should validate_presence_of(:graduation_year)}
     it {should validate_presence_of(:position)}
   end
+
+  describe 'relationships' do
+    it {should belong_to(:team).optional}
+  end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -6,4 +6,8 @@ RSpec.describe Team, type: :model do
     it {should validate_presence_of(:age_group)}
     it {should validate_presence_of(:coach)}
   end
+
+  describe 'relationships' do
+    it {should have_many(:players)}
+  end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Team, type: :model do
   describe 'validations' do
     it {should validate_presence_of(:name)}
     it {should validate_presence_of(:age_group)}
-    it {should validate_presence_of(:coach)}
   end
 
   describe 'relationships' do
     it {should have_many(:players)}
+    it {should have_many(:users)}
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,12 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   describe 'validations' do
+    it {should validate_presence_of(:full_name)}
     it {should validate_presence_of(:email)}
     it {should validate_presence_of(:password)}
+  end
+
+  describe 'relationships' do
+    it {should belong_to(:team).optional}
   end
 end

--- a/spec/requests/api/v0/login_request_spec.rb
+++ b/spec/requests/api/v0/login_request_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'User Login Endpoint Request' do
   it 'A successful response returns an auth_token with a 200 status' do
-    user = User.create( email: 'sample.coach@mobile.edu',
+    user = User.create( full_name: 'John Doe',
+                        email: 'sample.coach@mobile.edu',
                         password: 'samplepassword')
 
     payload = { email: user.email, password: user.password}.to_json
@@ -18,8 +19,9 @@ RSpec.describe 'User Login Endpoint Request' do
   end
 
   it 'Incorrect login credentials return 401 error message' do
-    user_2 = User.create( email: 'sample.coach_2@mobile.edu',
-                        password: 'password')
+    user_2 = User.create( full_name: 'Peter Smith',
+                          email: 'sample.coach_2@mobile.edu',
+                          password: 'password')
 
     payload = { email: user_2.email, password: 'invalidpassword'}.to_json
     post '/api/v0/login', params: payload


### PR DESCRIPTION
- Add one to many relationship between user and teams (a team can have many coaches)
- Add one to many relationship between player and teams (a team can have many players)
- Add relationship migrations and updated schema
- Add model relationship testing
- Update seed file to use FactoryBot to create users(coaches), teams, and players.

Testing coverage
18 examples, 0 failures

Coverage report generated for RSpec to /Users/pauldebevec/technical_challenge/CaptianUAssessment/coverage. 73 / 73 LOC (100.0%) covered.