### PR TITLE
Pd/players

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'webpacker', '~> 4.0'
 gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.2', require: false
+gem 'jsonapi-serializer'
 
 gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,8 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    jsonapi-serializer (2.1.0)
+      activesupport (>= 4.2)
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -233,6 +235,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   jbuilder (~> 2.7)
+  jsonapi-serializer
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)
   pry

--- a/api_calls_responses.md
+++ b/api_calls_responses.md
@@ -5,10 +5,14 @@ Run your server locally to test calls in Postman (Default url should be http://l
 rails s
 ```
 
-Retrieve auth_token by logging in with an authorized user:
+Legend: Height is in cm, weight is in pounds.
+
+`/login` endpoint - Retrieve auth_token by logging in with an authorized user:
 ```sh
 POST api/v0/login
 ```
+
+
 In the body of your request, include the following raw json:
 ```sh
 {
@@ -22,5 +26,90 @@ Expected response:
 {
     "auth_token": "EyKRyQBFUj/RamVp/3cmuqTS7SBheqC4x+iRC+xx1bijHyQgYrxUA5MxYeYwKVALvfId0MqLNkcaie6jb/+auiU/47+vMHQC6PTHk3f/u/6LW0zlJTd8T2+uTFXu5TqQsA1MiacK3ecnmOXGFzo+UUgzLZMDIaisNTTHyDvJXcC3/1xA7OAGrC5Ok+KAypAlDIYh0khY+jX1C3jIhDI4aGSeJPeHmFHVNfptou383qTfy2RoOUT99LFcxMfSQUpkeoXBaqajAaFFgi6Swpyuzp0GGJhc5cFb7QBjfOcwhUN616PRK+NWOR+Kp3X7c2UzlIMmyb4eDY+SedaE+3xxO8KTgsVIRFQymyeOA0cJDDT9RXb0xNxMgXk7AeMuPzZ36U8ZOP1lfNvfEALTfAe9IvL4sAd7OTzDsNvLFe+cxj2Z+mZ32TDORGmOUX9GBcdaBY6CaGdRod9nO5oi31q5M1G21uk+UXMwpl3VSOwsnMExVQ59hvHRR63xL/owWjLHhakXobbXI053yJwrayIXGA==",
     "message": "user authenticated"
+}
+```
+
+`/players` endpoint - Returns all players associated to the logged in user(coach)
+```sh
+GET api/v0/players
+```
+
+Note: If there is an active session the GET request will return the players as stated above. If there is not an active session, a valid `auth_token` may be sent through the headers to receive a successful response.
+
+Expected response:
+```sh
+{
+    "data": [
+        {
+            "id": "6",
+            "type": "players",
+            "attributes": {
+                "first_name": "Daina",
+                "last_name": "Funk",
+                "height": 199,
+                "weight": 131,
+                "birthday": "1998-08-11",
+                "graduation_year": 2020,
+                "position": "Point Guard",
+                "recruit": true
+            }
+        },
+        {
+            "id": "7",
+            "type": "players",
+            "attributes": {
+                "first_name": "Stacee",
+                "last_name": "Balistreri",
+                "height": 188,
+                "weight": 138,
+                "birthday": "2001-08-12",
+                "graduation_year": 2020,
+                "position": "Power Forward",
+                "recruit": true
+            }
+        },
+        {
+            "id": "8",
+            "type": "players",
+            "attributes": {
+                "first_name": "Harry",
+                "last_name": "Cremin",
+                "height": 183,
+                "weight": 204,
+                "birthday": "2001-11-01",
+                "graduation_year": 2023,
+                "position": "Shooting Guard",
+                "recruit": true
+            }
+        },
+        {
+            "id": "9",
+            "type": "players",
+            "attributes": {
+                "first_name": "Sanford",
+                "last_name": "Green",
+                "height": 191,
+                "weight": 164,
+                "birthday": "2002-01-29",
+                "graduation_year": 2019,
+                "position": "Center",
+                "recruit": true
+            }
+        },
+        {
+            "id": "10",
+            "type": "players",
+            "attributes": {
+                "first_name": "Shad",
+                "last_name": "Hartmann",
+                "height": 198,
+                "weight": 160,
+                "birthday": "2001-01-22",
+                "graduation_year": 2020,
+                "position": "Shooting Guard",
+                "recruit": true
+            }
+        }
+    ]
 }
 ```

--- a/app/controllers/api/v0/players_controller.rb
+++ b/app/controllers/api/v0/players_controller.rb
@@ -1,6 +1,16 @@
 class Api::V0::PlayersController < ApplicationController
   def index
-    players = current_user.team.players
-    render json: PlayersSerializer.new(players) if valid_auth_token?
+    user_in_session = User.find_by(id: session[:user_id])
+    if user_in_session.nil? && valid_auth_token?
+      coach = User.find_by(auth_token: request.headers['auth_token'])
+      players = coach.team.players
+      render json: PlayersSerializer.new(players)
+    elsif user_in_session != nil
+      players = user_in_session.team.players
+      render json: PlayersSerializer.new(players) if valid_auth_token?
+    else
+      message = "You do not have access to view this page"
+      render json: {'data': { 'message': message}}, status: 401
+    end
   end
 end

--- a/app/controllers/api/v0/players_controller.rb
+++ b/app/controllers/api/v0/players_controller.rb
@@ -1,4 +1,6 @@
 class Api::V0::PlayersController < ApplicationController
   def index
+    players = current_user.team.players
+    render json: PlayersSerializer.new(players) if valid_auth_token?
   end
 end

--- a/app/controllers/api/v0/players_controller.rb
+++ b/app/controllers/api/v0/players_controller.rb
@@ -1,0 +1,4 @@
+class Api::V0::PlayersController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/api/v0/sessions_controller.rb
+++ b/app/controllers/api/v0/sessions_controller.rb
@@ -2,10 +2,13 @@ class Api::V0::SessionsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def create
+    # Parse the body and make it readable JSON
     request_body = JSON.parse(request.body.read)
     user = User.find_by(email: request_body['email'])
     if user.authenticate(request_body['password'])
-      user.generate_api_token
+      # Generates auth token for user when they log in for the first time
+      user.generate_auth_token if user.auth_token == nil
+      session[:user_id] = user.id
       message = "user authenticated"
       render json: {'auth_token' => user.auth_token, 'message' => message}, status: 200
     else

--- a/app/controllers/api/v0/sessions_controller.rb
+++ b/app/controllers/api/v0/sessions_controller.rb
@@ -1,5 +1,4 @@
 class Api::V0::SessionsController < ApplicationController
-  skip_before_action :verify_authenticity_token
 
   def create
     # Parse the body and make it readable JSON

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::Base
+  helper_method :current_user, :valid_auth_token?
+
+  def current_user
+    current_user ||= User.find(session[:user_id]) if session[:user_id]
+  end
+
+  def valid_auth_token?
+    return true if current_user.auth_token != nil
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  skip_before_action :verify_authenticity_token
   helper_method :current_user, :valid_auth_token?
 
   def current_user
@@ -6,6 +7,9 @@ class ApplicationController < ActionController::Base
   end
 
   def valid_auth_token?
-    return true if current_user.auth_token != nil
+    return true if current_user&.auth_token
+
+    token = request.headers['auth_token'] || request.headers['HTTP_AUTH_TOKEN']
+    return true if User.find_by(auth_token: token)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
 
   belongs_to :team, optional: true
 
-  def generate_api_token
+  def generate_auth_token
     token = AuthTokenGenerator.generate_token
     self.update(auth_token: token)
   end

--- a/app/serializers/players_serializer.rb
+++ b/app/serializers/players_serializer.rb
@@ -1,0 +1,4 @@
+class PlayersSerializer
+  include JSONAPI::Serializer
+  attributes :first_name, :last_name, :height, :weight, :birthday, :graduation_year, :position, :recruit
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v0 do
       post '/login', to: 'sessions#create'
+      resources :players, only: [:index]
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,6 +2,14 @@ User.destroy_all
 Player.destroy_all
 Team.destroy_all
 
+team = Team.create(name: 'Spartans', age_group: '16-18')
+coach = team.users.create(full_name: 'Bader Coach', email: 'sample.coach@mobile.edu', password: 'samplepassword',
+  auth_token: 'NHa/tjwQOJxDTUzG1XTSYvgr0ru9iqCcXsG3Ovwl8OjcVOE8B67zMHrhcn+z34Lf1HXIb1WeDOoFyGn8+58Q26ookmMaJTHVG9a19sfeEPoabKShCFSJToBM',
+  team_id: team.id)
+
+team.update(coach: coach.full_name)
+team_players = FactoryBot.create_list(:player, 5)
+team.players << team_players
 
 coach_and_team_1 = FactoryBot.create(:user, team_id: FactoryBot.create(:team).id)
 coach_and_team_1.team.update(coach: coach_and_team_1.full_name)
@@ -26,6 +34,7 @@ team_5 = coach_and_team_5.team
 coach_and_team_6 = FactoryBot.create(:user, team_id: FactoryBot.create(:team).id)
 coach_and_team_6.team.update(coach: coach_and_team_6.full_name)
 team_6 = coach_and_team_6.team
+
 
 team_1_players = FactoryBot.create_list(:player, 5)
 team_1.players << team_1_players

--- a/spec/factories/players.rb
+++ b/spec/factories/players.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     height  { Faker::Number.between(from: 152, to: 200) }
     weight  { Faker::Number.between(from: 130, to: 220) }
     birthday  { Faker::Date.between(from: '1998-01-01', to: '2003-01-01') }
-    graduation_year  { 2021 }
+    graduation_year  { Faker::Number.between(from: 2019, to: 2023) }
     position  { Faker::Sports::Basketball.position }
-    recruit  { Faker::Boolean.boolean }
+    recruit  { true }
   end
 end

--- a/spec/requests/api/v0/login_request_spec.rb
+++ b/spec/requests/api/v0/login_request_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'User Login Endpoint Request' do
 
     payload = { email: user.email, password: user.password}.to_json
     post '/api/v0/login', params: payload
-
     expect(response).to be_successful
     expect(response.status).to eq(200)
     json = JSON.parse(response.body, symbolize_names: true)

--- a/spec/requests/api/v0/player_request_spec.rb
+++ b/spec/requests/api/v0/player_request_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe 'User Login Endpoint Request' do
+  it 'A successful response returns an auth_token with a 200 status' do
+
+    # Create a user with random name, random email, and password of 'password'
+    coach_and_team_1 = FactoryBot.create(:user , team_id: FactoryBot.create(:team).id)
+    coach_and_team_1.team.update(coach: coach_and_team_1.full_name)
+    # Update user email to 'samplecoach@example.com'
+    coach_and_team_1.update(email: 'samplecoach@example.com')
+    team_1 = coach_and_team_1.team
+
+    coach_and_team_2 = FactoryBot.create(:user, team_id: FactoryBot.create(:team).id)
+    coach_and_team_2.team.update(coach: coach_and_team_2.full_name)
+    team_2 = coach_and_team_2.team
+
+    team_1_players = FactoryBot.create_list(:player, 5)
+    team_1.players << team_1_players
+
+    team_2_players = FactoryBot.create_list(:player, 5)
+    team_2.players << team_2_players
+
+    payload = { email: 'samplecoach@example.com', password: 'password'}.to_json
+    post '/api/v0/login', params: payload
+
+    # Begin test for '/players' endpoint
+    get '/api/v0/players'
+    expect(response).to be_successful
+    expect(response.status).to eq(200)
+    json = JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/spec/requests/api/v0/player_request_spec.rb
+++ b/spec/requests/api/v0/player_request_spec.rb
@@ -83,4 +83,35 @@ RSpec.describe 'User Login Endpoint Request' do
     expect(json[:data][0][:attributes].length).to eq(8)
     expect(json[:data].length).to eq(5)
   end
+
+  it 'API sends 401 response to users who do not have a valid auth_token' do
+    # Create a user with random name, random email, and password of 'password'
+    coach_and_team_1 = FactoryBot.create(:user , team_id: FactoryBot.create(:team).id)
+    coach_and_team_1.team.update(coach: coach_and_team_1.full_name)
+    # Update user email to 'samplecoach@example.com'
+    coach_and_team_1.update(auth_token: 'NHa/tjwQOJxDTUzG1XTSYvgr0ru9iqCcXsG3Ovwl8OjcVOE8B67zMHrhcn+z34Lf1HXIb1WeDOoFyGn8+58Q26ookmMaJTHVG9a19sfeEPoabKShCFSJToBM')
+    team_1 = coach_and_team_1.team
+    team_1_players = FactoryBot.create_list(:player, 5)
+    team_1.players << team_1_players
+
+    message = 'user authorized'
+    # Begin test for '/players' endpoint
+    payload_2 = { auth_token: 'non_existant_auth_token', message: message }
+
+    get '/api/v0/players', headers: payload_2
+
+    expect(response).not_to be_successful
+    expect(response.status).to eq(401)
+    json = JSON.parse(response.body, symbolize_names: true)
+    expect(json[:data][:message]).to eq('You do not have access to view this page')
+  end
+
+  it 'API sends 401 response to users who are not logged in' do
+    get '/api/v0/players'
+
+    expect(response).not_to be_successful
+    expect(response.status).to eq(401)
+    json = JSON.parse(response.body, symbolize_names: true)
+    expect(json[:data][:message]).to eq('You do not have access to view this page')
+  end
 end

--- a/spec/requests/api/v0/player_request_spec.rb
+++ b/spec/requests/api/v0/player_request_spec.rb
@@ -26,7 +26,45 @@ RSpec.describe 'User Login Endpoint Request' do
     post '/api/v0/login', params: payload
 
     # Begin test for '/players' endpoint
-    get '/api/v0/players'
+    payload_2 = { auth_token: coach_and_team_1.auth_token, message: 'user authorized' }.to_json
+
+    get '/api/v0/players', params: payload_2
+
+    expect(response).to be_successful
+    expect(response.status).to eq(200)
+    json = JSON.parse(response.body, symbolize_names: true)
+    expect(json[:data][0].keys.include?(:id)).to eq(true)
+    expect(json[:data][0].keys.include?(:type)).to eq(true)
+    expect(json[:data][0].keys.include?(:attributes)).to eq(true)
+    expect(json[:data][0][:type]).to eq('players')
+    expect(json[:data][0][:attributes].keys.include?(:first_name)).to eq(true)
+    expect(json[:data][0][:attributes].keys.include?(:last_name)).to eq(true)
+    expect(json[:data][0][:attributes].keys.include?(:height)).to eq(true)
+    expect(json[:data][0][:attributes].keys.include?(:weight)).to eq(true)
+    expect(json[:data][0][:attributes].keys.include?(:birthday)).to eq(true)
+    expect(json[:data][0][:attributes].keys.include?(:graduation_year)).to eq(true)
+    expect(json[:data][0][:attributes].keys.include?(:position)).to eq(true)
+    expect(json[:data][0][:attributes].keys.include?(:recruit)).to eq(true)
+    expect(json[:data][0][:attributes].length).to eq(8)
+    expect(json[:data].length).to eq(5)
+  end
+
+  it 'API sends responds to an auth_token being sent through the headers of the request' do
+    # Create a user with random name, random email, and password of 'password'
+    coach_and_team_1 = FactoryBot.create(:user , team_id: FactoryBot.create(:team).id)
+    coach_and_team_1.team.update(coach: coach_and_team_1.full_name)
+    # Update user email to 'samplecoach@example.com'
+    coach_and_team_1.update(auth_token: 'NHa/tjwQOJxDTUzG1XTSYvgr0ru9iqCcXsG3Ovwl8OjcVOE8B67zMHrhcn+z34Lf1HXIb1WeDOoFyGn8+58Q26ookmMaJTHVG9a19sfeEPoabKShCFSJToBM')
+    team_1 = coach_and_team_1.team
+    team_1_players = FactoryBot.create_list(:player, 5)
+    team_1.players << team_1_players
+
+    message = 'user authorized'
+    # Begin test for '/players' endpoint
+    payload_2 = { auth_token: coach_and_team_1.auth_token, message: message }
+
+    get '/api/v0/players', headers: payload_2
+
     expect(response).to be_successful
     expect(response.status).to eq(200)
     json = JSON.parse(response.body, symbolize_names: true)

--- a/spec/requests/api/v0/player_request_spec.rb
+++ b/spec/requests/api/v0/player_request_spec.rb
@@ -2,12 +2,14 @@ require 'rails_helper'
 
 RSpec.describe 'User Login Endpoint Request' do
   it 'A successful response returns an auth_token with a 200 status' do
-
+    # Setup
     # Create a user with random name, random email, and password of 'password'
     coach_and_team_1 = FactoryBot.create(:user , team_id: FactoryBot.create(:team).id)
     coach_and_team_1.team.update(coach: coach_and_team_1.full_name)
     # Update user email to 'samplecoach@example.com'
     coach_and_team_1.update(email: 'samplecoach@example.com')
+    coach_and_team_1.update(auth_token: 'NHa/tjwQOJxDTUzG1XTSYvgr0ru9iqCcXsG3Ovwl8OjcVOE8B67zMHrhcn+z34Lf1HXIb1WeDOoFyGn8+58Q26ookmMaJTHVG9a19sfeEPoabKShCFSJToBMcmKAjI4sXteWnsEedjzEj7sIAMefmk0T9u3/qoEiMmeC/D+l+FolynvopKcgsLLtHzexGK9Gfggfzyh2gzF81AbqXQMSYuoorrvZFpHDuMC3ZnN9dS9y0VCBg6FBdbSDRIVmVMDoBhXMdpk7FjtSswMwO39+rgcBfHKs8Ve0PqQN2DVgJRg5c8UybdXgye7wUcXu01jRlX1AJvuzIJ5dhCZC7weLFFEmDk6cieSmRCcJg8oLdLxD9DChTC28UqrB2ybA82j+4K2DFh1I1nojpu8Ue5Dyh9WvpR1ClhqMnMtH4nXJqEwb0tOIaLz2qNqbRgE0aHlO1lCfueF3d1Hg2LLi4SjktAIzsPF0QZgjVYNjXAjdTQe/X/GPEAyl/OLoXMlQ/OjUuqstPwVp9T6cZ8IhaEPrtQ')
+
     team_1 = coach_and_team_1.team
 
     coach_and_team_2 = FactoryBot.create(:user, team_id: FactoryBot.create(:team).id)
@@ -28,5 +30,19 @@ RSpec.describe 'User Login Endpoint Request' do
     expect(response).to be_successful
     expect(response.status).to eq(200)
     json = JSON.parse(response.body, symbolize_names: true)
+    expect(json[:data][0].keys.include?(:id)).to eq(true)
+    expect(json[:data][0].keys.include?(:type)).to eq(true)
+    expect(json[:data][0].keys.include?(:attributes)).to eq(true)
+    expect(json[:data][0][:type]).to eq('players')
+    expect(json[:data][0][:attributes].keys.include?(:first_name)).to eq(true)
+    expect(json[:data][0][:attributes].keys.include?(:last_name)).to eq(true)
+    expect(json[:data][0][:attributes].keys.include?(:height)).to eq(true)
+    expect(json[:data][0][:attributes].keys.include?(:weight)).to eq(true)
+    expect(json[:data][0][:attributes].keys.include?(:birthday)).to eq(true)
+    expect(json[:data][0][:attributes].keys.include?(:graduation_year)).to eq(true)
+    expect(json[:data][0][:attributes].keys.include?(:position)).to eq(true)
+    expect(json[:data][0][:attributes].keys.include?(:recruit)).to eq(true)
+    expect(json[:data][0][:attributes].length).to eq(8)
+    expect(json[:data].length).to eq(5)
   end
 end


### PR DESCRIPTION
- Add `api/v0/players` endpoint.
- Add testing coverage for a successful response and an unauthorized response.
- Add multiple access points through a session, as well as sending the auth_token through the headers.
- Add `valid_auth_token?` method to check an auth token upon the request.
- Add jsonapi-serializer gem to generate serializers to format the response
- Add seeds to the seed file for mock data. 

Testing coverage:
22 examples, 0 failures

Coverage report generated for RSpec to /Users/pauldebevec/technical_challenge/CaptianUAssessment/coverage. 179 / 179 LOC (100.0%) covered.