### PR TITLE
Pd/assessments

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -1,0 +1,3 @@
+class Assessment < ApplicationRecord
+  validates_presence_of :rating, :assessment_type
+end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -1,3 +1,7 @@
 class Assessment < ApplicationRecord
-  validates_presence_of :rating, :assessment_type
+  validates_presence_of :rating, :assessment_type, :player_id, :user_id, :tournament_id
+
+  belongs_to :user
+  belongs_to :player
+  belongs_to :tournament
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -3,4 +3,5 @@ class Player < ApplicationRecord
                         :graduation_year, :position
 
   belongs_to :team, optional: true
+  has_many :assessments
 end

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -3,4 +3,5 @@ class Tournament < ApplicationRecord
 
   has_many :tournament_teams
   has_many :teams, through: :tournament_teams
+  has_many :assessments
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   validates_presence_of :full_name, :email, :password
 
   belongs_to :team, optional: true
+  has_many :assessments
 
   def generate_auth_token
     token = AuthTokenGenerator.generate_token

--- a/db/migrate/20210225012545_create_assessments.rb
+++ b/db/migrate/20210225012545_create_assessments.rb
@@ -1,0 +1,8 @@
+class CreateAssessments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :assessments do |t|
+      t.float :rating
+      t.string :assessment_type, default: 'event'
+    end
+  end
+end

--- a/db/migrate/20210225014056_add_player_to_assessments.rb
+++ b/db/migrate/20210225014056_add_player_to_assessments.rb
@@ -1,0 +1,5 @@
+class AddPlayerToAssessments < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :assessments, :player, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20210225014134_add_user_to_assessments.rb
+++ b/db/migrate/20210225014134_add_user_to_assessments.rb
@@ -1,0 +1,5 @@
+class AddUserToAssessments < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :assessments, :user, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20210225014152_add_tournament_to_assessments.rb
+++ b/db/migrate/20210225014152_add_tournament_to_assessments.rb
@@ -1,0 +1,5 @@
+class AddTournamentToAssessments < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :assessments, :tournament, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,6 +15,11 @@ ActiveRecord::Schema.define(version: 2021_02_25_003055) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "assessments", force: :cascade do |t|
+    t.float "rating"
+    t.string "assessment_type", default: "event"
+  end
+
   create_table "players", force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_25_003055) do
+ActiveRecord::Schema.define(version: 2021_02_25_014152) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,6 +18,12 @@ ActiveRecord::Schema.define(version: 2021_02_25_003055) do
   create_table "assessments", force: :cascade do |t|
     t.float "rating"
     t.string "assessment_type", default: "event"
+    t.bigint "player_id", null: false
+    t.bigint "user_id", null: false
+    t.bigint "tournament_id", null: false
+    t.index ["player_id"], name: "index_assessments_on_player_id"
+    t.index ["tournament_id"], name: "index_assessments_on_tournament_id"
+    t.index ["user_id"], name: "index_assessments_on_user_id"
   end
 
   create_table "players", force: :cascade do |t|
@@ -68,6 +74,9 @@ ActiveRecord::Schema.define(version: 2021_02_25_003055) do
     t.index ["team_id"], name: "index_users_on_team_id"
   end
 
+  add_foreign_key "assessments", "players"
+  add_foreign_key "assessments", "tournaments"
+  add_foreign_key "assessments", "users"
   add_foreign_key "players", "teams"
   add_foreign_key "users", "teams"
 end

--- a/spec/models/assessments_spec.rb
+++ b/spec/models/assessments_spec.rb
@@ -4,5 +4,14 @@ RSpec.describe Assessment, type: :model do
   describe 'validations' do
     it {should validate_presence_of(:rating)}
     it {should validate_presence_of(:assessment_type)}
+    it {should validate_presence_of(:user_id)}
+    it {should validate_presence_of(:tournament_id)}
+    it {should validate_presence_of(:player_id)}
+  end
+
+  describe 'relationships' do
+    it {should belong_to(:user)}
+    it {should belong_to(:tournament)}
+    it {should belong_to(:player)}
   end
 end

--- a/spec/models/assessments_spec.rb
+++ b/spec/models/assessments_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Assessment, type: :model do
+  describe 'validations' do
+    it {should validate_presence_of(:rating)}
+    it {should validate_presence_of(:assessment_type)}
+  end
+end

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -13,5 +13,6 @@ RSpec.describe Player, type: :model do
 
   describe 'relationships' do
     it {should belong_to(:team).optional}
+    it {should have_many(:assessments)}
   end
 end

--- a/spec/models/tournament_spec.rb
+++ b/spec/models/tournament_spec.rb
@@ -11,5 +11,6 @@ RSpec.describe Tournament, type: :model do
   describe 'relationships' do
     it {should have_many(:tournament_teams)}
     it {should have_many(:teams).through(:tournament_teams)}
+    it {should have_many(:assessments)}
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,5 +9,6 @@ RSpec.describe User, type: :model do
 
   describe 'relationships' do
     it {should belong_to(:team).optional}
+    it {should have_many(:assessments)}
   end
 end


### PR DESCRIPTION
- Create Assessments model tests and model
- Create migration to add assessments
- Add assessments to schema
- Add testing and functionality for one to many relationship between assessments and players, tournaments, users.
- Update schema for one to many relationship

Testing Coverage: 
45 examples, 0 failures

Coverage report generated for RSpec to /Users/pauldebevec/technical_challenge/CaptianUAssessment/coverage. 232 / 232 LOC (100.0%) covered.
